### PR TITLE
Fix react-warning-keys

### DIFF
--- a/src/Jazzicon.js
+++ b/src/Jazzicon.js
@@ -52,6 +52,7 @@ export default class Jazzicon extends React.PureComponent {
 
     return (
       <rect
+        key={i}
         x="0"
         y="0"
         rx="0"


### PR DESCRIPTION
Fix console warning for missing `key` prop on mapped element.