### PR TITLE
Add dependency for color module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "marcusmolchany",
   "license": "MIT",
   "dependencies": {
+    "color": "^0.11.0",
     "mersenne-twister": "^1.1.0",
     "prop-types": "^15.5.10"
   },


### PR DESCRIPTION
Currently importing `react-jazzicon` fails when the `color` package is not installed. Furthermore, it seems we cannot use the newest version of `color` due to some interface change, so I've set it to the same version the original `jazzicon` package depends on.